### PR TITLE
fix: vue-style-loader supports ES modules

### DIFF
--- a/service/config/css.js
+++ b/service/config/css.js
@@ -23,7 +23,6 @@ const genStyleRules = () => {
       // how many loaders before css-loader should be applied to [@import]ed resources.
       // stylePostLoader injected by vue-loader + postcss-loader
       importLoaders: 1 + 1,
-      esModule: false, // css-loader using ES Modules as default in v4, but vue-style-loader support cjs only.
     },
   }
   const postcssLoader = {


### PR DESCRIPTION
- `vue-style-loader` supports ES modules in [v4.1.3](https://github.com/vuejs/vue-style-loader/releases)

- Using ES modules is beneficial to module concatenation and tree shaking

- the default value of [esModule](https://github.com/webpack-contrib/style-loader#esmodule) option in `style-loader` is `true`